### PR TITLE
Database script to automate build of PostgreSQL server on EC2

### DIFF
--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -8,7 +8,7 @@ mkdir /data/databases # Create data_directory
 sudo service postgresql96 initdb --pgdata=/data/databases
 sudo service postgresql96 start
 # Note: this should prompt for console input to set the 'postgres' OS account password
-# <<CONSOLE INPUT>>
+# <<EXPECT CONSOLE INPUT>>
 sudo -u postgres passwd
 
 # TODO: set the password for the 'postgres' database account
@@ -24,34 +24,34 @@ sudo -u postgres psql --command '\password postgres'
 # 2018 disaster-resilience project
 ROLENAME="disaster-resilience"
 DBNAME_SUFFIX=""
-# <<CONSOLE INPUT>>
+# <<EXPECT CONSOLE INPUT>>
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 housing-affordability project
-ROLENAME=""
+ROLENAME="housing-affordability"
 DBNAME_SUFFIX=""
-# <<CONSOLE INPUT>>
+# <<EXPECT CONSOLE INPUT>>
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 local-elections project
-ROLENAME=""
+ROLENAME="local-elections"
 DBNAME_SUFFIX=""
-# <<CONSOLE INPUT>>
+# <<EXPECT CONSOLE INPUT>>
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 transportation-systems project
-ROLENAME=""
+ROLENAME="transportation-systems"
 DBNAME_SUFFIX=""
-# <<CONSOLE INPUT>>
+# <<EXPECT CONSOLE INPUT>>
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 urban-development project
-ROLENAME=""
+ROLENAME="urban-development"
 DBNAME_SUFFIX=""
-# <<CONSOLE INPUT>>
+# <<EXPECT CONSOLE INPUT>>
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -3,10 +3,16 @@
 # TODO: declare the yum package as a variable up front for visibility
 
 sudo yum update -y
-sudo yum install postgresql96.x86_64
+sudo amazon-linux-extras install postgresql9.6 # enables postgres9.6 install on Amazon Linux 2
+sudo yum install postgresql.x86_64 postgresql-server.x86_64 # aliases to postgresql 9.6.6-1.amzn2.0.1 as of 2018-02-25
+
 mkdir /data/databases # Create data_directory
-sudo service postgresql96 initdb --pgdata=/data/databases
-sudo service postgresql96 start
+sudo chown postgres /data/databases
+
+# sudo service postgresql96 initdb --pgdata=/data/databases # I believe this worked on Amazon Linux (not AL "2")
+sudo -u postgres initdb --pgdata=/data/databases
+sudo service postgresql96 start # errors out - 'Directory "/var/lib/pgsql/data" is missing or empty.''
+
 # Note: this should prompt for console input to set the 'postgres' OS account password
 # <<EXPECT CONSOLE INPUT>>
 sudo -u postgres passwd

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -1,24 +1,35 @@
 #! /bin/sh
 # Creates the PostgreSQL database server to host all 2018 Hack Oregon season project's databases
 # Usage: scp this file to [ec2_machine_DNS:~ then run script as ec2user]
+# 
+# Prerequisites:
+# EC2 machine is already created and running
 
 POSTGRES_PACKAGE="postgresql9.6"
+DATABASE_SERVICE="postgresql"
 
 sudo yum update -y
 sudo amazon-linux-extras install $POSTGRES_PACKAGE # enables postgres9.6 install on Amazon Linux 2
 sudo yum install postgresql.x86_64 postgresql-server.x86_64 # aliases to postgresql 9.6.6-1.amzn2.0.1 as of 2018-02-25
 
-DATA_DIRECTORY="/databases" # Assumes secondary volume is mounted as /data
+DATA_DIRECTORY="/data/databases" # Assumes EBS volume is mounted as /data
 
 sudo mkdir $DATA_DIRECTORY
+# PostgreSQL requires the $PGDATA directory to have exclusive ownership and access
 sudo chown -R postgres:postgres $DATA_DIRECTORY
 sudo chmod 700 $DATA_DIRECTORY
 
 POSTGRES_OVERRIDE_DIRECTORY="/etc/systemd/system/postgresql.service.d"
 
+# 'systemctl edit postgresql.service' runs interactively, so this is an alternative to provide an override
+sudo mkdir $POSTGRES_OVERRIDE_DIRECTORY
+#sudo touch $POSTGRES_OVERRIDE_DIRECTORY/override.conf
 # Create the override.conf file to enable postgresql.service to use non-default DATA_DIRECTORY
-sudo echo '[Service]' >> ${POSTGRES_OVERRIDE_DIRECTORY}/override.conf
-sudo echo 'Environment=PGDATA=' $DATA_DIRECTORY >> ${POSTGRES_OVERRIDE_DIRECTORY}/override.conf
+# NOTE: https://superuser.com/questions/136646/how-to-append-to-a-file-as-sudo#136653 explains how to gain write permission as the non-shell user
+echo '' | sudo tee -a $POSTGRES_OVERRIDE_DIRECTORY/override.conf
+echo '[Service]' | sudo tee -a $POSTGRES_OVERRIDE_DIRECTORY/override.conf
+echo 'Environment=PGDATA='$DATA_DIRECTORY | sudo tee -a $POSTGRES_OVERRIDE_DIRECTORY/override.conf
+#sudo cp --no-preserve=mode,ownership override.conf $POSTGRES_OVERRIDE_DIRECTORY
 sudo systemctl daemon-reload # reload systemd to read in override.conf
 
 cd / # necessary to work around a permissions issues between sudo and the /home/ec2_user directory
@@ -30,68 +41,78 @@ sudo /usr/bin/postgresql-setup --initdb --unit postgresql
 #sudo -u postgres initdb --pgdata=$DATA_DIRECTORY
 #sudo -u postgres postgresql-setup --initdb --datadir $DATA_DIRECTORY
 
-# >>>>> 
-# >>>>>
-# Alternative: initdb, then copy /var/lib/pgsql/data to /data/databases
-# then change data directory to destination_data_directory within /var/lib/pgsql/data/postgresql.conf
-# then start the service
-# .>>>>
-# >>>>>
+echo "Configuring PostgreSQL to listen for all incoming IP addresses..."
+echo '' | sudo tee -a ${DATA_DIRECTORY}/postgresql.conf
+echo '# Overriding default listener behaviour via build script' | sudo tee -a ${DATA_DIRECTORY}/postgresql.conf
+echo "listen_addresses = '*'" | sudo tee -a ${DATA_DIRECTORY}/postgresql.conf
+
+echo "Enabling all database users to login from all IP addresses..."
+echo -e 'host all all 0.0.0.0/0 md5' | sudo tee -a ${DATA_DIRECTORY}/pg_hba.conf
+
+echo "Enabling PostgreSQL service to be persistent..."
+sudo systemctl enable ${DATABASE_SERVICE}.service # 'sudo service $DATABASE_SERVICE enable' doesn't work here
 
 echo "Starting PostgreSQL..."
-sudo service postgresql start # errors out - 'Directory "/var/lib/pgsql/data" is missing or empty.''
-
-# TODO: determine if we need to configure the service to start automatically, and if 'service' is preferred over 'systemctl'
-# systemctl enable postgresql.service
+sudo service $DATABASE_SERVICE start
 
 # TODO: is it *less* secure to set a password for this account?
-echo "Setting password for OS account postgres..."
-sudo -u postgres passwd
+#echo "Setting password for OS account postgres..."
+#sudo -u postgres passwd
 
 # TODO: set the password for the 'postgres' database account
-
+echo "Setting password for postgres database account..."
 # This approach is untested
 #read -p "Setting password for DB user postgres - type in the password:" DB_password
 #sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '$DB_password';"
-
 # -OR-
 sudo -u postgres psql --command '\password postgres'
 
 # Create databases and their roles
 # NOTE: the database naming convention is the project name + data purpose
 # e.g. createdb -O transportation-systems transportation-systems-conflicts
+# TODO: investigate PostgreSQL Roles to determine if there's any advantage over assigning ownership to the Database
 
 # 2018 disaster-resilience project
 ROLENAME="disaster-resilience"
 DBNAME_SUFFIX=""
+DBNAME_FULL=${ROLENAME}-${DBNAME_SUFFIX}
 echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
-sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+sudo -u postgres createdb -O $ROLENAME $DBNAME_FULL
+#echo -e 'host ' ${DBNAME_FULL} ' ' ${ROLENAME} ' 0.0.0.0/0 md5' | sudo tee -a ${DATA_DIRECTORY}/pg_hba.conf
 
 # 2018 housing-affordability project
 ROLENAME="housing-affordability"
 DBNAME_SUFFIX=""
+DBNAME_FULL=${ROLENAME}-${DBNAME_SUFFIX}
 echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
-sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+sudo -u postgres createdb -O $ROLENAME $DBNAME_FULL
 
 # 2018 local-elections project
 ROLENAME="local-elections"
 DBNAME_SUFFIX=""
+DBNAME_FULL=${ROLENAME}-${DBNAME_SUFFIX}
 echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
-sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+sudo -u postgres createdb -O $ROLENAME $DBNAME_FULL
 
 # 2018 transportation-systems project
 ROLENAME="transportation-systems"
 DBNAME_SUFFIX=""
+DBNAME_FULL=${ROLENAME}-${DBNAME_SUFFIX}
 echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
-sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+sudo -u postgres createdb -O $ROLENAME $DBNAME_FULL
 
 # 2018 urban-development project
 ROLENAME="urban-development"
 DBNAME_SUFFIX=""
+DBNAME_FULL=${ROLENAME}-${DBNAME_SUFFIX}
 echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
-sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+sudo -u postgres createdb -O $ROLENAME $DBNAME_FULL
+
+
+# HUP the database service in case any .conf files were altered since last start
+sudo -u postgres pg_ctl reload --pgdata=${DATA_DIRECTORY} # sends SIGHUP to postgres server

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -11,7 +11,8 @@ sudo yum install postgresql.x86_64 postgresql-server.x86_64 # aliases to postgre
 DATA_DIRECTORY="/data/databases" # Assumes secondary volume is mounted as /data
 
 sudo mkdir $DATA_DIRECTORY
-sudo chown postgres $DATA_DIRECTORY
+sudo chown -R postgres:postgres $DATA_DIRECTORY
+sudo chmod 700 $DATA_DIRECTORY
 
 echo "Initializing PostgreSQL..."
 sudo -u postgres postgres -c "initdb -D $DATA_DIRECTORY" # suggested by Ed

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -1,0 +1,57 @@
+#! /bin/sh
+# Creates the PostgreSQL database server to host all 2018 Hack Oregon season project's databases
+# TODO: declare the yum package as a variable up front for visibility
+
+sudo yum update -y
+sudo yum install postgresql96.x86_64
+mkdir /data/databases # Create data_directory
+sudo service postgresql96 initdb --pgdata=/data/databases
+sudo service postgresql96 start
+# Note: this should prompt for console input to set the 'postgres' OS account password
+# <<CONSOLE INPUT>>
+sudo -u postgres passwd
+
+# TODO: set the password for the 'postgres' database account
+sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'newpassword';"
+# -OR-
+sudo -u postgres psql --command '\password postgres'
+
+# Create databases and their roles
+# NOTE: the dbname will always be the project name + data purpose
+# e.g. createdb -O transportation-systems transportation-systems-conflicts
+# Note: this should prompt for console input to set each database role's password
+
+# 2018 disaster-resilience project
+ROLENAME="disaster-resilience"
+DBNAME_SUFFIX=""
+# <<CONSOLE INPUT>>
+sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
+sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+
+# 2018 housing-affordability project
+ROLENAME=""
+DBNAME_SUFFIX=""
+# <<CONSOLE INPUT>>
+sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
+sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+
+# 2018 local-elections project
+ROLENAME=""
+DBNAME_SUFFIX=""
+# <<CONSOLE INPUT>>
+sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
+sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+
+# 2018 transportation-systems project
+ROLENAME=""
+DBNAME_SUFFIX=""
+# <<CONSOLE INPUT>>
+sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
+sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
+
+# 2018 urban-development project
+ROLENAME=""
+DBNAME_SUFFIX=""
+# <<CONSOLE INPUT>>
+sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
+sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -1,67 +1,77 @@
 #! /bin/sh
 # Creates the PostgreSQL database server to host all 2018 Hack Oregon season project's databases
-# TODO: declare the yum package as a variable up front for visibility
+# Usage: scp this file to [ec2_machine_DNS:~ then run script as ec2user]
+
+POSTGRES_PACKAGE="postgresql9.6"
 
 sudo yum update -y
-sudo amazon-linux-extras install postgresql9.6 # enables postgres9.6 install on Amazon Linux 2
+sudo amazon-linux-extras install $POSTGRES_PACKAGE # enables postgres9.6 install on Amazon Linux 2
 sudo yum install postgresql.x86_64 postgresql-server.x86_64 # aliases to postgresql 9.6.6-1.amzn2.0.1 as of 2018-02-25
 
-DATA_DIRECTORY="/data/databases"
+DATA_DIRECTORY="/data/databases" # Assumes secondary volume is mounted as /data
 
-# Assumes secondary volume is mounted as /data
-
-mkdir $DATA_DIRECTORY
+sudo mkdir $DATA_DIRECTORY
 sudo chown postgres $DATA_DIRECTORY
 
-# sudo service postgresql96 initdb --pgdata=/data/databases # I believe this worked on Amazon Linux (not AL "2")
-sudo -u postgres initdb --pgdata=$DATA_DIRECTORY
-sudo service postgresql96 start # errors out - 'Directory "/var/lib/pgsql/data" is missing or empty.''
+echo "Initializing PostgreSQL..."
+# sudo service postgresql96 initdb --pgdata=/data/databases # This is the usual documented approach but doesn't work in Amazon Linux 2
+#sudo -u postgres initdb --pgdata=$DATA_DIRECTORY
+sudo -u postgres postgresql-setup --initdb --datadir $DATA_DIRECTORY
 
-# Note: this should prompt for console input to set the 'postgres' OS account password
-# <<EXPECT CONSOLE INPUT>>
+echo "Starting PostgreSQL..."
+sudo service postgresql start # errors out - 'Directory "/var/lib/pgsql/data" is missing or empty.''
+
+# TODO: determine if we need to configure the service to start automatically, and if 'service' is preferred over 'systemctl'
+# systemctl enable postgresql.service
+
+# TODO: is it *less* secure to set a password for this account?
+echo "Setting password for OS account postgres..."
 sudo -u postgres passwd
 
 # TODO: set the password for the 'postgres' database account
-sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'newpassword';"
+
+# This approach is untested
+#read -p "Setting password for DB user postgres - type in the password:" DB_password
+#sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '$DB_password';"
+
 # -OR-
 sudo -u postgres psql --command '\password postgres'
 
 # Create databases and their roles
-# NOTE: the dbname will always be the project name + data purpose
+# NOTE: the database naming convention is the project name + data purpose
 # e.g. createdb -O transportation-systems transportation-systems-conflicts
-# Note: this should prompt for console input to set each database role's password
 
 # 2018 disaster-resilience project
 ROLENAME="disaster-resilience"
 DBNAME_SUFFIX=""
-# <<EXPECT CONSOLE INPUT>>
+echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 housing-affordability project
 ROLENAME="housing-affordability"
 DBNAME_SUFFIX=""
-# <<EXPECT CONSOLE INPUT>>
+echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 local-elections project
 ROLENAME="local-elections"
 DBNAME_SUFFIX=""
-# <<EXPECT CONSOLE INPUT>>
+echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 transportation-systems project
 ROLENAME="transportation-systems"
 DBNAME_SUFFIX=""
-# <<EXPECT CONSOLE INPUT>>
+echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}
 
 # 2018 urban-development project
 ROLENAME="urban-development"
 DBNAME_SUFFIX=""
-# <<EXPECT CONSOLE INPUT>>
+echo "Creating DB user $ROLENAME - prompts for password..."
 sudo -u postgres createuser --encrypted --pwprompt --no-createdb --no-createrole --no-superuser --no-replication $ROLENAME
 sudo -u postgres createdb -O $ROLENAME ${ROLENAME}-${DBNAME_SUFFIX}

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -6,11 +6,15 @@ sudo yum update -y
 sudo amazon-linux-extras install postgresql9.6 # enables postgres9.6 install on Amazon Linux 2
 sudo yum install postgresql.x86_64 postgresql-server.x86_64 # aliases to postgresql 9.6.6-1.amzn2.0.1 as of 2018-02-25
 
-mkdir /data/databases # Create data_directory
-sudo chown postgres /data/databases
+DATA_DIRECTORY="/data/databases"
+
+# Assumes secondary volume is mounted as /data
+
+mkdir $DATA_DIRECTORY
+sudo chown postgres $DATA_DIRECTORY
 
 # sudo service postgresql96 initdb --pgdata=/data/databases # I believe this worked on Amazon Linux (not AL "2")
-sudo -u postgres initdb --pgdata=/data/databases
+sudo -u postgres initdb --pgdata=$DATA_DIRECTORY
 sudo service postgresql96 start # errors out - 'Directory "/var/lib/pgsql/data" is missing or empty.''
 
 # Note: this should prompt for console input to set the 'postgres' OS account password

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -14,9 +14,11 @@ sudo mkdir $DATA_DIRECTORY
 sudo chown postgres $DATA_DIRECTORY
 
 echo "Initializing PostgreSQL..."
-# sudo service postgresql96 initdb --pgdata=/data/databases # This is the usual documented approach but doesn't work in Amazon Linux 2
+sudo -u postgres postgres -c "initdb -D $DATA_DIRECTORY" # suggested by Ed
+#sudo /usr/bin/postgresql-setup --initdb --unit postgresql
+#sudo service postgresql initdb --pgdata=$DATA_DIRECTORY # This is the usual documented approach but use the specified the DATA_DIRECTORY
 #sudo -u postgres initdb --pgdata=$DATA_DIRECTORY
-sudo -u postgres postgresql-setup --initdb --datadir $DATA_DIRECTORY
+#sudo -u postgres postgresql-setup --initdb --datadir $DATA_DIRECTORY
 
 echo "Starting PostgreSQL..."
 sudo service postgresql start # errors out - 'Directory "/var/lib/pgsql/data" is missing or empty.''

--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -3,7 +3,9 @@
 # Usage: scp this file to [ec2_machine_DNS:~ then run script as ec2user]
 # 
 # Prerequisites:
-# EC2 machine is already created and running
+# EC2 machine using Amazon Linux 2 AMI is already created and running
+# AWS 'amazon-linux-extras' package repo is available
+# EBS volume mounted as `/data` is available in which to store all databases
 
 POSTGRES_PACKAGE="postgresql9.6"
 DATABASE_SERVICE="postgresql"


### PR DESCRIPTION
## Goal
Script all steps to install and configure PostgreSQL server on an EC2 virtual machine.

## Prerequisites
This script performs that task with two prerequisites:
1. EC2 virtual machine (Amazon Linux 2) is running and `amazon-linux-extras` package repo is available.
2. An EBS volume mounted as `/data` is available in which all database instances will be stored.

## Accomplishments
- Installs PostgreSQL 9.6 (latest) from `amazon-linux-extras`
- Creates $PGDATA directory as /data/databases and configures `override.conf` to enable PGDATA override
- Initializes default database cluster with that PGDATA override, so that no database files are stored on the ephemeral EC2 root volume
- Enables all external connections to connect to all databases
- Enables the database service to persistently start
- Prompts to change the `postgres` database user's password
- Leaves the OS `postgres` account with its default blank password for security purposes
- Enables trivial automation to create database instances for each of the five 2018 season's Hack Oregon projects
- HUPs the database service in case any future changes are inserted for any of the `.conf` files