### PR TITLE
Mount EBS volume to /data given its device name

### DIFF
--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -3,19 +3,28 @@
 # Usage: scp this file to [ec2_machine_DNS:~ then run script as ec2user]
 # 
 # Prerequisites:
-# EC2 machine using Amazon Linux 2 AMI is already created and running
+# This EC2 instance is created with EBS volume named /dev/sdf
 # AWS 'amazon-linux-extras' package repo is available
 # EBS volume mounted as `/data` is available in which to store all databases
 
-DATA_DIRECTORY="/data/databases" # Assumes EBS volume is mounted as /data
+
+DATA_DIRECTORY="/data/databases"
 DATABASE_SERVICE="postgresql"
-POSTGRES_OVERRIDE_DIRECTORY="/etc/systemd/system/postgresql.service.d" # Location of override.conf
+POSTGRES_OVERRIDE_DIRECTORY="/etc/systemd/system/postgresql.service.d"
 POSTGRES_PACKAGE="postgresql9.6" # package installed from amazon-linux-extras repo
+
+MOUNT_POINT="/data"
+DEVICE_NAME="/dev/sdf" # Assume the EBS volume is configured as /dev/sdf
 
 echo 'Installing PostgreSQL packages...'
 sudo yum update -y
 sudo amazon-linux-extras install $POSTGRES_PACKAGE # enables postgres9.6 install on Amazon Linux 2
-sudo yum install postgresql.x86_64 postgresql-server.x86_64 # aliases to postgresql 9.6.6-1.amzn2.0.1 as of 2018-02-25
+sudo yum install postgresql.x86_64 postgresql-server.x86_64 -y # aliases to postgresql 9.6.6-1.amzn2.0.1 as of 2018-02-25
+
+echo 'Mounting EBS volume '"$DEVICE_NAME"' as '"$MOUNT_POINT"
+sudo mkfs -t ext4 $DEVICE_NAME
+sudo mkdir $MOUNT_POINT
+sudo mount -t ext4 $DEVICE_NAME $MOUNT_POINT
 
 echo 'Creating properly-configured $PGDATA data_directory...'
 sudo mkdir $DATA_DIRECTORY


### PR DESCRIPTION
Get rid of the prerequisite "having an EBS volume mounted to /data", given that we know the device name of the attached EBS volume