### PR TITLE
Additional automation for the data layer

### DIFF
--- a/bin/create-database-development.sh
+++ b/bin/create-database-development.sh
@@ -9,7 +9,8 @@
 # EBS volume mounted as `/data` is available in which to store all databases
 
 
-DATA_DIRECTORY="/data/postgresql/databases" #two directories deep to avoid PostgreSQL "direct mountpoint" warning - see http://www.postgresql.org/docs/9.6/static/creating-cluster.html
+DATA_DIRECTORY="/data/postgresql" #two directories deep to avoid PostgreSQL "direct mountpoint" warning - see http://www.postgresql.org/docs/9.6/static/creating-cluster.html
+DATABASES_DIRECTORY="${DATA_DIRECTORY}/databases"
 DATABASE_SERVICE="postgresql"
 DEVICE_NAME="/dev/sdb" # Assume the EBS volume is configured as /dev/sdb
 MOUNT_POINT="/data"
@@ -29,16 +30,17 @@ sudo mount -t ext4 $DEVICE_NAME $MOUNT_POINT
 
 echo 'Creating properly-configured $PGDATA data_directory...'
 sudo mkdir $DATA_DIRECTORY
+sudo mkdir $DATABASES_DIRECTORY
 # PostgreSQL requires the $PGDATA directory to have exclusive ownership and access
-sudo chown -R postgres:postgres $DATA_DIRECTORY
-sudo chmod 700 $DATA_DIRECTORY
+sudo chown -R postgres:postgres $DATABASES_DIRECTORY
+sudo chmod 700 $DATABASES_DIRECTORY
 
 # 'systemctl edit postgresql.service' runs interactively - this approach commits changes to the file without interaction
 echo 'Configuring override.conf to use the non-default data_directory...'
 sudo mkdir $POSTGRES_OVERRIDE_DIRECTORY
 echo '' | sudo tee -a $POSTGRES_OVERRIDE_DIRECTORY/override.conf # https://superuser.com/questions/136646/how-to-append-to-a-file-as-sudo#136653 explains how 'tee' enables write permission as the non-shell user
 echo '[Service]' | sudo tee -a $POSTGRES_OVERRIDE_DIRECTORY/override.conf
-echo 'Environment=PGDATA='$DATA_DIRECTORY | sudo tee -a $POSTGRES_OVERRIDE_DIRECTORY/override.conf
+echo 'Environment=PGDATA='$DATABASES_DIRECTORY | sudo tee -a $POSTGRES_OVERRIDE_DIRECTORY/override.conf
 sudo systemctl daemon-reload # reload systemd to read in override.conf
 
 cd / # necessary to work around a permissions issues between sudo and the /home/ec2_user directory
@@ -47,12 +49,12 @@ echo "Initializing PostgreSQL..."
 sudo /usr/bin/postgresql-setup --initdb --unit postgresql
 
 echo "Configuring PostgreSQL to listen for all incoming IP addresses..."
-echo '' | sudo tee -a ${DATA_DIRECTORY}/postgresql.conf
-echo '# Overriding default listener behaviour via build script' | sudo tee -a ${DATA_DIRECTORY}/postgresql.conf
-echo "listen_addresses = '*'" | sudo tee -a ${DATA_DIRECTORY}/postgresql.conf
+echo '' | sudo tee -a ${DATABASES_DIRECTORY}/postgresql.conf
+echo '# Overriding default listener behaviour via build script' | sudo tee -a ${DATABASES_DIRECTORY}/postgresql.conf
+echo "listen_addresses = '*'" | sudo tee -a ${DATABASES_DIRECTORY}/postgresql.conf
 
 echo "Enabling all database users to login from all IP addresses..."
-echo -e 'host all all 0.0.0.0/0 md5' | sudo tee -a ${DATA_DIRECTORY}/pg_hba.conf
+echo -e 'host all all 0.0.0.0/0 md5' | sudo tee -a ${DATABASES_DIRECTORY}/pg_hba.conf
 
 echo "Enabling PostgreSQL service to be persistent..."
 sudo systemctl enable ${DATABASE_SERVICE}.service # 'sudo service $DATABASE_SERVICE enable' doesn't work here

--- a/bin/create-ec2-machine-database.sh
+++ b/bin/create-ec2-machine-database.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+# if [ "$#" -ne 1 ]; then
+#     echo "Must has 1 argument as instance name"
+#     exit 1
+# fi
+
+DEVICENAME='/dev/sdb'
+IMAGEID='ami-7f43f307'
+INSTANCETYPE='t2.micro'
+KEYNAME='hackoregon-2018-database-dev-env'
+REGION='us-west-2'
+SECURITYGROUPIDS='sg-28154957'
+SUBNETID='subnet-8794fddf'
+VOLUMESIZE='8'
+
+instance_name=$1
+tag_specs='ResourceType=instance,Tags=[{Key=Name,Value='$instance_name'}]'
+echo $tag_specs
+aws ec2 run-instances \
+   --image-id $IMAGEID \
+   --count 1 \
+   --instance-type $INSTANCETYPE \
+   --key-name $KEYNAME \
+   --security-group-ids $SECURITYGROUPIDS \
+   --subnet-id $SUBNETID\
+   --region $REGION \
+   --block-device-mappings "[{\"DeviceName\":\"/dev/sdb\",\"Ebs\":{\"VolumeSize\":8,\"DeleteOnTermination\":true}}]" \
+   --tag-specifications $tag_specs \
+   --query 'Instances[0].InstanceId'


### PR DESCRIPTION
Two enhancements:
1. Updating the script that creates the PostgreSQL server, to mitigate the "direct mountpoint" warning with an additional directory.  (Also, it was silly of me to think I could create a nested directory in one step - very silly.)
2. Adding a script (started out by @khashf) to create the EC2 machine that will host the database server.