### PR TITLE
Enable EBS volume modification

### DIFF
--- a/bin/create-ec2-machine-database.sh
+++ b/bin/create-ec2-machine-database.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# TODO: change the VolumeType if necessary
+# TODO: disable DeleteOnTermination
+
 # if [ "$#" -ne 1 ]; then
 #     echo "Must has 1 argument as instance name"
 #     exit 1
@@ -25,6 +28,6 @@ aws ec2 run-instances \
    --security-group-ids $SECURITYGROUPIDS \
    --subnet-id $SUBNETID\
    --region $REGION \
-   --block-device-mappings "[{\"DeviceName\":\"/dev/sdb\",\"Ebs\":{\"VolumeSize\":8,\"DeleteOnTermination\":true}}]" \
+   --block-device-mappings "[{\"DeviceName\":\"/dev/sdb\",\"Ebs\":{\"VolumeSize\":8,\"VolumeType\":\"gp2\",\"DeleteOnTermination\":true}}]" \
    --tag-specifications $tag_specs \
    --query 'Instances[0].InstanceId'


### PR DESCRIPTION
Modifying the volume type to a type that supports EBS volume size modification ("standard" type, which is the default, does not support volume size modification).

Also leaving behind a couple of TODOs to make this script less brittle (and to keep the EBS volume).