### PR TITLE
Securely grant ec2 read access to s3 before downloading files from s3

### DIFF
--- a/bin/create-ec2-machine-database.sh
+++ b/bin/create-ec2-machine-database.sh
@@ -8,6 +8,7 @@ fi
 DEVICENAME='/dev/sdb'
 IMAGEID='ami-7f43f307'
 INSTANCETYPE='t2.micro'
+INSTANCE_PROFILE_NAME='s3access-profile'
 KEYNAME='hackoregon-2018-database-dev-env'
 REGION='us-west-2'
 SECURITYGROUPIDS='sg-28154957'
@@ -24,6 +25,7 @@ aws ec2 run-instances \
    --image-id $IMAGEID \
    --count 1 \
    --instance-type $INSTANCETYPE \
+   --iam-instance-profile Name=$INSTANCE_PROFILE_NAME \
    --key-name $KEYNAME \
    --security-group-ids $SECURITYGROUPIDS \
    --subnet-id $SUBNETID\

--- a/bin/ec2-role-access-policy.json
+++ b/bin/ec2-role-access-policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:*"],
+        "Resource": ["*"]
+      }
+    ]
+  }

--- a/bin/ec2-role-trust-policy.json
+++ b/bin/ec2-role-trust-policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": { "Service": "ec2.amazonaws.com"},
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }

--- a/bin/grant-ec2-read-access-s3
+++ b/bin/grant-ec2-read-access-s3
@@ -1,0 +1,41 @@
+#!/bin/bash -e
+
+ROLE_NAME='s3access'
+TRUST_POLICY_FILE='file://ec2-role-trust-policy.json'
+ACCESS_POLICY_FILE='file://ec2-role-access-policy.json'
+ACCESS_POLICY_NAME='S3-Permissions'
+INSTANCE_PROFILE_NAME='s3access-profile'
+
+echo
+echo "Creating IAM role named \"$ROLE_NAME\""
+aws iam create-role \
+    --role-name $ROLE_NAME \
+    --assume-role-policy-document $TRUST_POLICY_FILE
+
+echo
+echo "Attaching the access policy \"$ACCESS_POLICY_FILE\" to role \"$ROLE_NAME\" "
+aws iam put-role-policy \
+    --role-name $ROLE_NAME \
+    --policy-name $ACCESS_POLICY_NAME \
+    --policy-document $ACCESS_POLICY_FILE
+
+echo
+echo "Creating an instance profile named \"$INSTANCE_PROFILE_NAME\" "
+aws iam create-instance-profile \
+    --instance-profile-name $INSTANCE_PROFILE_NAME
+
+echo
+echo "Adding the role named \"$ROLE_NAME\" to the instance profile named \"$INSTANCE_PROFILE_NAME\" "
+aws iam add-role-to-instance-profile \
+    --instance-profile-name $INSTANCE_PROFILE_NAME \
+    --role-name $ROLE_NAME
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Changes:

- Added 2 policy JSON files that specify read permission to s3
- Added a script creating an instance profile that grants the to-be-launch ec2 instance read access permission to s3 using 2 added JSON policy files above.
- Modified `create-ec2-machine-database.sh` to launch ec2 instance with the created instance profile

References:

- [Using 'assume role' to securely grant ec2 read access to s3 instance](https://optimalbi.com/blog/2016/07/12/aws-tips-and-tricks-moving-files-from-s3-to-ec2-instance/)
- [AWS manual: IAM Roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)