### PR TITLE
Add policy to ec2 on-launch that allows it to read from s3

### DIFF
--- a/bin/create-ec2-machine-database.sh
+++ b/bin/create-ec2-machine-database.sh
@@ -11,6 +11,7 @@
 DEVICENAME='/dev/sdb'
 IMAGEID='ami-7f43f307'
 INSTANCETYPE='t2.micro'
+INSTANCEPROFILE='s3access-profile'
 KEYNAME='hackoregon-2018-database-dev-env'
 REGION='us-west-2'
 SECURITYGROUPIDS='sg-28154957'
@@ -24,6 +25,7 @@ aws ec2 run-instances \
    --image-id $IMAGEID \
    --count 1 \
    --instance-type $INSTANCETYPE \
+   --iam-instance-profile Name=$INSTANCEPROFILE \
    --key-name $KEYNAME \
    --security-group-ids $SECURITYGROUPIDS \
    --subnet-id $SUBNETID\

--- a/bin/create-instance-profile.sh
+++ b/bin/create-instance-profile.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+ROLE_NAME='s3access'
+TRUST_POLICY_FILE='file://ec2-role-trust-policy.json'
+ACCESS_POLICY_FILE='file://ec2-role-access-policy.json'
+ACCESS_POLICY_NAME='S3-Permissions'
+INSTANCE_PROFILE_NAME='s3access-profile'
+
+echo
+echo "Creating IAM role named \"$ROLE_NAME\""
+aws iam create-role \
+    --role-name $ROLE_NAME \
+    --assume-role-policy-document $TRUST_POLICY_FILE
+
+echo
+echo "Attaching the access policy \"$ACCESS_POLICY_FILE\" to role \"$ROLE_NAME\" "
+aws iam put-role-policy \
+    --role-name $ROLE_NAME \
+    --policy-name $ACCESS_POLICY_NAME \
+    --policy-document $ACCESS_POLICY_FILE
+
+echo
+echo "Creating an instance profile named \"$INSTANCE_PROFILE_NAME\" "
+aws iam create-instance-profile \
+    --instance-profile-name $INSTANCE_PROFILE_NAME
+
+echo
+echo "Adding the role named \"$ROLE_NAME\" to the instance profile named \"$INSTANCE_PROFILE_NAME\" "
+aws iam add-role-to-instance-profile \
+    --instance-profile-name $INSTANCE_PROFILE_NAME \
+    --role-name $ROLE_NAME
+

--- a/bin/ec2-role-access-policy.json
+++ b/bin/ec2-role-access-policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:*"],
+        "Resource": ["*"]
+      }
+    ]
+  }

--- a/bin/ec2-role-trust-policy.json
+++ b/bin/ec2-role-trust-policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": { "Service": "ec2.amazonaws.com"},
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }


### PR DESCRIPTION
Given that the policy of s3 also allow other services (include ec2) read from its buckets and files